### PR TITLE
TickRate API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,32 @@
 # TickRate
 The source code for [TickRate](https://modrinth.com/mod/tick)
 
+## API
+From TickRate v0.3.0 onwards, an API is exposed to allow other mods to programmatically use the `/tick` command. The API consists of 2 parts:
+1. `TickRateAPI` - Basically the `/tick` command in API form. Obtain the API instance via `TickRateAPI.getInstance()`.
+2. `TickRateEvents` - Events that fire when a server/entity/chunk's tick rate/status is modified. Registering event handlers is identical to Fabric's events.
+
+To use the API in your mod, first add the [Modrinth Maven repository](https://support.modrinth.com/en/articles/8801191-modrinth-maven#h_fac44e6b48). 
+Then, add the dependency in this format:
+
+```groovy
+dependencies {
+    // e.g. modImplementation "maven.modrinth:tick:0.3.0-1.21.4"
+    modImplementation "maven.modrinth:tick:${mod_version}-${mc_version}"
+}
+```
+
+The API's documentation is provided by the sources/javadoc JAR hosted on the same repository. Make sure to download them via your IDE.
+
 ## Some cool datapacks
 These datapacks require the TickRate mod to function.
 
 _This is being released here because I can't be bothered to create another Modrinth project just for this :P_
 
-1. EntityRandomTickRate (TickRate <a download href="https://github.com/DennisOchulor/TickRate/raw/refs/heads/main/datapacks/EntityRandomTickRate 0.1.x.zip">0.1.x</a> / <a download href="https://github.com/DennisOchulor/TickRate/raw/refs/heads/main/datapacks/EntityRandomTickRate 0.2.x.zip">0.2.x</a>)
+1. EntityRandomTickRate (TickRate <a download href="https://github.com/DennisOchulor/TickRate/raw/refs/heads/main/datapacks/EntityRandomTickRate 0.1.x.zip">0.1.x</a> / <a download href="https://github.com/DennisOchulor/TickRate/raw/refs/heads/main/datapacks/EntityRandomTickRate 0.2.x.zip">0.2.x+</a>)
 
    A datapack that randomises the tick rate of every entity (except players).
 
-2. ChunkRandomTickRate (TickRate <a download href="https://github.com/DennisOchulor/TickRate/raw/refs/heads/main/datapacks/ChunkRandomTickRate 0.1.x.zip">0.1.x</a> / <a download href="https://github.com/DennisOchulor/TickRate/raw/refs/heads/main/datapacks/ChunkRandomTickRate 0.2.x.zip">0.2.x</a>)
+2. ChunkRandomTickRate (TickRate <a download href="https://github.com/DennisOchulor/TickRate/raw/refs/heads/main/datapacks/ChunkRandomTickRate 0.1.x.zip">0.1.x</a> / <a download href="https://github.com/DennisOchulor/TickRate/raw/refs/heads/main/datapacks/ChunkRandomTickRate 0.2.x.zip">0.2.x+</a>)
 
    A datapack that randomises the tick rate of every chunk.

--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,7 @@ java {
 	// if it is present.
 	// If you remove this line, sources will not be generated.
 	withSourcesJar()
+	withJavadocJar()
 
 	sourceCompatibility = JavaVersion.VERSION_21
 	targetCompatibility = JavaVersion.VERSION_21
@@ -95,5 +96,12 @@ publishing {
 		// Notice: This block does NOT have the same function as the block in the top level.
 		// The repositories here will be used for publishing your artifact, not for
 		// retrieving dependencies.
+	}
+}
+
+javadoc {
+	include "io/github/dennisochulor/tickrate/api/**"
+	tasks.withType(Javadoc) {
+		options.addStringOption('Xdoclint:none', '-quiet')
 	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 	id 'maven-publish'
 }
 
-version = project.mod_version
+version = "${project.mod_version}-${project.minecraft_version}"
 group = project.maven_group
 
 base {

--- a/src/main/java/io/github/dennisochulor/tickrate/TickRate.java
+++ b/src/main/java/io/github/dennisochulor/tickrate/TickRate.java
@@ -1,5 +1,6 @@
 package io.github.dennisochulor.tickrate;
 
+import io.github.dennisochulor.tickrate.api_impl.TickRateAPIImpl;
 import net.fabricmc.api.ModInitializer;
 
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerEntityEvents;
@@ -42,6 +43,7 @@ public class TickRate implements ModInitializer {
 
 		ServerLifecycleEvents.SERVER_STARTING.register(server -> {
 			server.getTickManager().tickRate$serverStarted();
+			TickRateAPIImpl.init(server);
 		});
 
 		ServerLifecycleEvents.AFTER_SAVE.register((server, flush, force) -> { // for autosaves and when server stops

--- a/src/main/java/io/github/dennisochulor/tickrate/TickRate.java
+++ b/src/main/java/io/github/dennisochulor/tickrate/TickRate.java
@@ -1,14 +1,19 @@
 package io.github.dennisochulor.tickrate;
 
 import io.github.dennisochulor.tickrate.api_impl.TickRateAPIImpl;
+import io.github.dennisochulor.tickrate.test.Test;
 import net.fabricmc.api.ModInitializer;
 
+import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerEntityEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
+import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.command.argument.EntityArgumentType;
 import net.minecraft.server.ServerTickManager;
+import net.minecraft.server.command.CommandManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,10 +46,9 @@ public class TickRate implements ModInitializer {
 			tickManager.tickRate$sendUpdatePacket();
 		}));
 
-		ServerLifecycleEvents.SERVER_STARTING.register(server -> {
-			server.getTickManager().tickRate$serverStarted();
-			TickRateAPIImpl.init(server);
-		});
+		ServerLifecycleEvents.SERVER_STARTING.register(server -> server.getTickManager().tickRate$serverStarted());
+
+		ServerLifecycleEvents.SERVER_STARTED.register(TickRateAPIImpl::init);
 
 		ServerLifecycleEvents.AFTER_SAVE.register((server, flush, force) -> { // for autosaves and when server stops
 			server.getTickManager().tickRate$saveData();
@@ -61,6 +65,16 @@ public class TickRate implements ModInitializer {
 			ServerTickManager tickManager = (ServerTickManager) serverWorld.getTickManager();
 			tickManager.tickRate$updateEntityLoad(entity,false);
 		});
+
+		// TickRate testing command
+		if(FabricLoader.getInstance().isDevelopmentEnvironment()) {
+			CommandRegistrationCallback.EVENT.register((dispatcher, registryAccess, environment) -> {
+				dispatcher.register(CommandManager.literal("tickratetest").then(CommandManager.argument("entity", EntityArgumentType.entity()).executes(context -> {
+					Test.test(EntityArgumentType.getEntity(context, "entity"));
+					return 1;
+				})));
+			});
+		}
 
 	}
 

--- a/src/main/java/io/github/dennisochulor/tickrate/TickRate.java
+++ b/src/main/java/io/github/dennisochulor/tickrate/TickRate.java
@@ -50,6 +50,8 @@ public class TickRate implements ModInitializer {
 
 		ServerLifecycleEvents.SERVER_STARTED.register(TickRateAPIImpl::init);
 
+		ServerLifecycleEvents.SERVER_STOPPING.register(server -> TickRateAPIImpl.uninit());
+
 		ServerLifecycleEvents.AFTER_SAVE.register((server, flush, force) -> { // for autosaves and when server stops
 			server.getTickManager().tickRate$saveData();
 		});

--- a/src/main/java/io/github/dennisochulor/tickrate/TickRate.java
+++ b/src/main/java/io/github/dennisochulor/tickrate/TickRate.java
@@ -72,6 +72,10 @@ public class TickRate implements ModInitializer {
 				dispatcher.register(CommandManager.literal("tickratetest").then(CommandManager.argument("entity", EntityArgumentType.entity()).executes(context -> {
 					Test.test(EntityArgumentType.getEntity(context, "entity"));
 					return 1;
+				}))
+				.then(CommandManager.literal("server").executes(context -> {
+					Test.test(context.getSource().getServer());
+					return 1;
 				})));
 			});
 		}

--- a/src/main/java/io/github/dennisochulor/tickrate/api/TickRateAPI.java
+++ b/src/main/java/io/github/dennisochulor/tickrate/api/TickRateAPI.java
@@ -10,14 +10,15 @@ import java.util.Collection;
 
 /**
  * API v0 for TickRate v0.3.0 <p>
- * This class represents the sole entrypoint for TickRate's API. This API should only be used on the server-side.
+ * This class represents the sole entrypoint for TickRate's API. This API should only be used on the logical server. <p>
  *
  * @see TickRateEvents
  */
 public interface TickRateAPI {
 
     /**
-     * Obtain the API instance. This method should only be called after the server has been fully initialised.
+     * Obtain the API instance. This method should only be called after the server has been fully initialised. <p>
+     * In singleplayer, a new API instance is used each time a new save is loaded.
      * @throws IllegalStateException if the server has not been fully intialised yet.
      */
     static TickRateAPI getInstance() {

--- a/src/main/java/io/github/dennisochulor/tickrate/api/TickRateAPI.java
+++ b/src/main/java/io/github/dennisochulor/tickrate/api/TickRateAPI.java
@@ -9,10 +9,10 @@ import net.minecraft.world.World;
 import java.util.Collection;
 
 /**
- * API v0 for TickRate v0.3.0
- * <p>
+ * API v0 for TickRate v0.3.0 <p>
  * This class represents the sole entrypoint for TickRate's API. This API should only be used on the server-side.
  */
+ @SuppressWarnings("unused")
 public interface TickRateAPI {
 
     /**
@@ -34,45 +34,170 @@ public interface TickRateAPI {
      */
     float queryEntity(Entity entity);
 
+    /**
+     * Sets the tick rate of the specified entities. <code>rate</code> is rounded using {@link Math#round(float)}
+     *
+     * @throws IllegalArgumentException if {@link Entity#isRemoved()} is true for any of the specified entities.
+     */
     void rateEntity(Collection<? extends Entity> entities, float rate);
 
+    /**
+     * Sets the tick rate of the specified entity. <code>rate</code> is rounded using {@link Math#round(float)}
+     *
+     * @throws IllegalArgumentException if {@link Entity#isRemoved()} is true.
+     */
     void rateEntity(Entity entity, float rate);
 
+    /**
+     * Freezes or unfreezes the specified entities depending on <code>freeze</code>.
+     *
+     * @param freeze <code>true</code> to freeze, <code>false</code> to unfreeze
+     * @throws IllegalArgumentException if {@link Entity#isRemoved()} is true for any of the specified entities.
+     */
     void freezeEntity(Collection<? extends Entity> entities, boolean freeze);
 
+    /**
+     * Freezes or unfreezes the specified entity depending on <code>freeze</code>.
+     *
+     * @param freeze <code>true</code> to freeze, <code>false</code> to unfreeze
+     * @throws IllegalArgumentException if {@link Entity#isRemoved()} is true the specified entity.
+     */
     void freezeEntity(Entity entity, boolean freeze);
 
+    /**
+     * Steps the specified entities for <code>stepTicks</code> ticks. The entities will step according to their current TPS. <p>
+     * If <code>stepTicks</code> is 0, the entities will stop stepping.
+     *
+     * @throws IllegalArgumentException if any of the following conditions are met: <p>
+     * <ul>
+     *          <li> {@link Entity#isRemoved()} is true for any of the specified entities.
+     *          <li> Any of the specified entities are currently NOT frozen or ARE sprinting.
+     * </ul>
+     */
     void stepEntity(Collection<? extends Entity> entities, int stepTicks);
 
+    /**
+     * Steps the specified entity for <code>stepTicks</code> ticks. The entity will step according to its current TPS. <p>
+     * If <code>stepTicks</code> is 0, the entitiy will stop stepping.
+     *
+     * @throws IllegalArgumentException if any of the following conditions are met: <p>
+     * <ul>
+     *          <li> {@link Entity#isRemoved()} is true.
+     *          <li> The specified entity is currently NOT frozen or IS sprinting.
+     * </ul>
+     */
     void stepEntity(Entity entity, int stepTicks);
 
+    /**
+     * Sprints the specified entities for <code>sprintTicks</code> ticks. <p>
+     * If <code>sprintTicks</code> is 0, the entities will stop sprinting.
+     *
+     * @throws IllegalArgumentException if any of the following conditions are met: <p>
+     * <ul>
+     *          <li> {@link Entity#isRemoved()} is true for any of the specified entities.
+     *          <li> Any of the specified entities are currently stepping.
+     * </ul>
+     */
     void sprintEntity(Collection<? extends Entity> entities, int sprintTicks);
 
+    /**
+     * Sprints the specified entity for <code>sprintTicks</code> ticks. <p>
+     * If <code>sprintTicks</code> is 0, the entity will stop sprinting.
+     *
+     * @throws IllegalArgumentException if any of the following conditions are met: <p>
+     * <ul>
+     *          <li> {@link Entity#isRemoved()} is true.
+     *          <li> The specified entity is currently stepping.
+     * </ul>
+     */
     void sprintEntity(Entity entity, int sprintTicks);
+
 
 
     /**
      * Returns the tick rate of the chunk. <p>
      * If the chunk has no specific tick rate, the server's tick rate will be returned.
      *
-     * @throws IllegalArgumentException if the chunk's level type is {@link ChunkLevelType#INACCESSIBLE INACCESSIBLE}.
+     * @throws IllegalArgumentException if the chunk is {@link ChunkLevelType#INACCESSIBLE INACCESSIBLE} (not loaded).
      */
     float queryChunk(World world, ChunkPos chunk);
 
+    /**
+     * Sets the tick rate of the specified chunks. <code>rate</code> is rounded using {@link Math#round(float)}
+     *
+     * @throws IllegalArgumentException if any of the chunks are {@link ChunkLevelType#INACCESSIBLE INACCESSIBLE} (not loaded).
+     */
     void rateChunk(Collection<? extends ChunkPos> chunks, float rate);
 
+    /**
+     * Sets the tick rate of the specified chunk. <code>rate</code> is rounded using {@link Math#round(float)}
+     *
+     * @throws IllegalArgumentException if the chunk is {@link ChunkLevelType#INACCESSIBLE INACCESSIBLE} (not loaded).
+     */
     void rateChunk(ChunkPos chunk, float rate);
 
+    /**
+     * Freezes or unfreezes the specified chunks depending on <code>freeze</code>.
+     *
+     * @param freeze <code>true</code> to freeze, <code>false</code> to unfreeze
+     * @throws IllegalArgumentException if any of the chunks are {@link ChunkLevelType#INACCESSIBLE INACCESSIBLE} (not loaded).
+     */
     void freezeChunk(Collection<? extends ChunkPos> chunks, boolean freeze);
 
+    /**
+     * Freezes or unfreezes the specified chunk depending on <code>freeze</code>.
+     *
+     * @param freeze <code>true</code> to freeze, <code>false</code> to unfreeze
+     * @throws IllegalArgumentException if the chunk is {@link ChunkLevelType#INACCESSIBLE INACCESSIBLE} (not loaded).
+     */
     void freezeChunk(ChunkPos chunk, boolean freeze);
 
+    /**
+     * Steps the specified chunks for <code>stepTicks</code> ticks. The chunks will step according to their current TPS. <p>
+     * If <code>stepTicks</code> is 0, the chunks will stop stepping.
+     *
+     * @throws IllegalArgumentException if any of the following conditions are met: <p>
+     * <ul>
+     *          <li> Any of the chunks are {@link ChunkLevelType#INACCESSIBLE INACCESSIBLE} (not loaded).
+     *          <li> Any of the specified chunks are currently NOT frozen or ARE sprinting.
+     * </ul>
+     */
     void stepChunk(Collection<? extends ChunkPos> chunks, int stepTicks);
 
+    /**
+     * Steps the specified chunk for <code>stepTicks</code> ticks. The chunk will step according to its current TPS. <p>
+     * If <code>stepTicks</code> is 0, the chunk will stop stepping.
+     *
+     * @throws IllegalArgumentException if any of the following conditions are met: <p>
+     * <ul>
+     *          <li> The chunk is {@link ChunkLevelType#INACCESSIBLE INACCESSIBLE} (not loaded).
+     *          <li> The specified chunk is currently NOT frozen or IS sprinting.
+     * </ul>
+     */
     void stepChunk(ChunkPos chunk, int stepTicks);
 
+    /**
+     * Sprints the specified chunks for <code>sprintTicks</code> ticks. <p>
+     * If <code>sprintTicks</code> is 0, the chunks will stop sprinting.
+     *
+     * @throws IllegalArgumentException if any of the following conditions are met: <p>
+     * <ul>
+     *          <li> Any of the chunks are {@link ChunkLevelType#INACCESSIBLE INACCESSIBLE} (not loaded).
+     *          <li> Any of the specified chunks are currently stepping.
+     * </ul>
+     */
     void sprintChunk(Collection<? extends ChunkPos> chunks, int sprintTicks);
 
+    /**
+     * Sprints the specified chunk for <code>sprintTicks</code> ticks. <p>
+     * If <code>sprintTicks</code> is 0, the chunk will stop sprinting.
+     *
+     * @throws IllegalArgumentException if any of the following conditions are met: <p>
+     * <ul>
+     *          <li> The chunk is {@link ChunkLevelType#INACCESSIBLE INACCESSIBLE} (not loaded).
+     *          <li> The specified chunk is currently stepping.
+     * </ul>
+     */
     void sprintChunk(ChunkPos chunk, int sprintTicks);
 
 }

--- a/src/main/java/io/github/dennisochulor/tickrate/api/TickRateAPI.java
+++ b/src/main/java/io/github/dennisochulor/tickrate/api/TickRateAPI.java
@@ -25,6 +25,44 @@ public interface TickRateAPI {
     }
 
     /**
+     * Returns the server's tick rate.
+     */
+    float queryServer();
+
+    /**
+     * Set the tick rate of the server. <code>rate</code> is rounded using {@link Math#round(float)}
+     *
+     * @throws IllegalArgumentException if <code>rate</code> is less than 1.
+     */
+    void rateServer(float rate);
+
+    /**
+     * Freezes or unfreezes the server depending on <code>freeze</code>.
+     *
+     * @param freeze <code>true</code> to freeze, <code>false</code> to unfreeze.
+     */
+    void freezeServer(boolean freeze);
+
+    /**
+     * Steps the server. The server will step according to its current TPS. <p>
+     * If <code>stepTicks</code> is 0, the server will stop stepping.
+     *
+     * @throws IllegalArgumentException if <code>stepTicks</code> is less than 0.
+     * @throws IllegalStateException if the server is not frozen.
+     */
+    void stepServer(int stepTicks);
+
+    /**
+     * Sprints the server. <p>
+     * If <code>sprintTicks</code> is 0, the server will stop sprinting.
+     *
+     * @throws IllegalArgumentException if <code>sprintTicks</code> is less than 0.
+     */
+    void sprintServer(int sprintTicks);
+
+
+
+    /**
      * Returns the tick rate of the entity. <p>
      * If the entity has no specific tick rate, the tick rate of the chunk it is in will be returned.
      * If the chunk it is in also has no specific tick rate, the server's tick rate will be returned. <p>

--- a/src/main/java/io/github/dennisochulor/tickrate/api/TickRateAPI.java
+++ b/src/main/java/io/github/dennisochulor/tickrate/api/TickRateAPI.java
@@ -11,8 +11,9 @@ import java.util.Collection;
 /**
  * API v0 for TickRate v0.3.0 <p>
  * This class represents the sole entrypoint for TickRate's API. This API should only be used on the server-side.
+ *
+ * @see TickRateEvents
  */
- @SuppressWarnings("unused")
 public interface TickRateAPI {
 
     /**

--- a/src/main/java/io/github/dennisochulor/tickrate/api/TickRateAPI.java
+++ b/src/main/java/io/github/dennisochulor/tickrate/api/TickRateAPI.java
@@ -35,16 +35,18 @@ public interface TickRateAPI {
     float queryEntity(Entity entity);
 
     /**
-     * Sets the tick rate of the specified entities. <code>rate</code> is rounded using {@link Math#round(float)}
+     * Sets the tick rate of the specified entities. <code>rate</code> is rounded using {@link Math#round(float)} <p>
+     * If <code>rate</code> is exactly <code>0.0f</code>, then the entities' tick rate will be reset.
      *
-     * @throws IllegalArgumentException if {@link Entity#isRemoved()} is true for any of the specified entities.
+     * @throws IllegalArgumentException if {@link Entity#isRemoved()} is true for any of the specified entities OR if <code>rate</code> is less than 1 and not 0.
      */
     void rateEntity(Collection<? extends Entity> entities, float rate);
 
     /**
-     * Sets the tick rate of the specified entity. <code>rate</code> is rounded using {@link Math#round(float)}
+     * Sets the tick rate of the specified entity. <code>rate</code> is rounded using {@link Math#round(float)} <p>
+     * If <code>rate</code> is exactly <code>0.0f</code>, then the entity's tick rate will be reset.
      *
-     * @throws IllegalArgumentException if {@link Entity#isRemoved()} is true.
+     * @throws IllegalArgumentException if {@link Entity#isRemoved()} is true OR if <code>rate</code> is less than 1 and not 0.
      */
     void rateEntity(Entity entity, float rate);
 
@@ -72,6 +74,7 @@ public interface TickRateAPI {
      * <ul>
      *          <li> {@link Entity#isRemoved()} is true for any of the specified entities.
      *          <li> Any of the specified entities are currently NOT frozen or ARE sprinting.
+     *          <li> <code>stepTicks</code> is less than 0.
      * </ul>
      */
     void stepEntity(Collection<? extends Entity> entities, int stepTicks);
@@ -84,6 +87,7 @@ public interface TickRateAPI {
      * <ul>
      *          <li> {@link Entity#isRemoved()} is true.
      *          <li> The specified entity is currently NOT frozen or IS sprinting.
+     *          <li> <code>stepTicks</code> is less than 0.
      * </ul>
      */
     void stepEntity(Entity entity, int stepTicks);
@@ -96,6 +100,7 @@ public interface TickRateAPI {
      * <ul>
      *          <li> {@link Entity#isRemoved()} is true for any of the specified entities.
      *          <li> Any of the specified entities are currently stepping.
+     *          <li> <code>sprintTicks</code> is less than 0.
      * </ul>
      */
     void sprintEntity(Collection<? extends Entity> entities, int sprintTicks);
@@ -108,6 +113,7 @@ public interface TickRateAPI {
      * <ul>
      *          <li> {@link Entity#isRemoved()} is true.
      *          <li> The specified entity is currently stepping.
+     *          <li> <code>sprintTicks</code> is less than 0.
      * </ul>
      */
     void sprintEntity(Entity entity, int sprintTicks);
@@ -123,18 +129,20 @@ public interface TickRateAPI {
     float queryChunk(World world, ChunkPos chunk);
 
     /**
-     * Sets the tick rate of the specified chunks. <code>rate</code> is rounded using {@link Math#round(float)}
+     * Sets the tick rate of the specified chunks. <code>rate</code> is rounded using {@link Math#round(float)} <p>
+     * If <code>rate</code> is exactly <code>0.0f</code>, then the chunks' tick rate will be reset.
      *
-     * @throws IllegalArgumentException if any of the chunks are {@link ChunkLevelType#INACCESSIBLE INACCESSIBLE} (not loaded).
+     * @throws IllegalArgumentException if any of the chunks are {@link ChunkLevelType#INACCESSIBLE INACCESSIBLE} (not loaded) OR if <code>rate</code> is less than 1 and not 0.
      */
-    void rateChunk(Collection<? extends ChunkPos> chunks, float rate);
+    void rateChunk(World world, Collection<ChunkPos> chunks, float rate);
 
     /**
-     * Sets the tick rate of the specified chunk. <code>rate</code> is rounded using {@link Math#round(float)}
+     * Sets the tick rate of the specified chunk. <code>rate</code> is rounded using {@link Math#round(float)} <p>
+     * If <code>rate</code> is exactly <code>0.0f</code>, then the chunk's tick rate will be reset.
      *
-     * @throws IllegalArgumentException if the chunk is {@link ChunkLevelType#INACCESSIBLE INACCESSIBLE} (not loaded).
+     * @throws IllegalArgumentException if the chunk is {@link ChunkLevelType#INACCESSIBLE INACCESSIBLE} (not loaded) OR if <code>rate</code> is less than 1 and not 0.
      */
-    void rateChunk(ChunkPos chunk, float rate);
+    void rateChunk(World world, ChunkPos chunk, float rate);
 
     /**
      * Freezes or unfreezes the specified chunks depending on <code>freeze</code>.
@@ -142,7 +150,7 @@ public interface TickRateAPI {
      * @param freeze <code>true</code> to freeze, <code>false</code> to unfreeze
      * @throws IllegalArgumentException if any of the chunks are {@link ChunkLevelType#INACCESSIBLE INACCESSIBLE} (not loaded).
      */
-    void freezeChunk(Collection<? extends ChunkPos> chunks, boolean freeze);
+    void freezeChunk(World world, Collection<ChunkPos> chunks, boolean freeze);
 
     /**
      * Freezes or unfreezes the specified chunk depending on <code>freeze</code>.
@@ -150,7 +158,7 @@ public interface TickRateAPI {
      * @param freeze <code>true</code> to freeze, <code>false</code> to unfreeze
      * @throws IllegalArgumentException if the chunk is {@link ChunkLevelType#INACCESSIBLE INACCESSIBLE} (not loaded).
      */
-    void freezeChunk(ChunkPos chunk, boolean freeze);
+    void freezeChunk(World world, ChunkPos chunk, boolean freeze);
 
     /**
      * Steps the specified chunks for <code>stepTicks</code> ticks. The chunks will step according to their current TPS. <p>
@@ -160,9 +168,10 @@ public interface TickRateAPI {
      * <ul>
      *          <li> Any of the chunks are {@link ChunkLevelType#INACCESSIBLE INACCESSIBLE} (not loaded).
      *          <li> Any of the specified chunks are currently NOT frozen or ARE sprinting.
+     *          <li> <code>stepTicks</code> is less than 0.
      * </ul>
      */
-    void stepChunk(Collection<? extends ChunkPos> chunks, int stepTicks);
+    void stepChunk(World world, Collection<ChunkPos> chunks, int stepTicks);
 
     /**
      * Steps the specified chunk for <code>stepTicks</code> ticks. The chunk will step according to its current TPS. <p>
@@ -172,9 +181,10 @@ public interface TickRateAPI {
      * <ul>
      *          <li> The chunk is {@link ChunkLevelType#INACCESSIBLE INACCESSIBLE} (not loaded).
      *          <li> The specified chunk is currently NOT frozen or IS sprinting.
+     *          <li> <code>stepTicks</code> is less than 0.
      * </ul>
      */
-    void stepChunk(ChunkPos chunk, int stepTicks);
+    void stepChunk(World world, ChunkPos chunk, int stepTicks);
 
     /**
      * Sprints the specified chunks for <code>sprintTicks</code> ticks. <p>
@@ -184,9 +194,10 @@ public interface TickRateAPI {
      * <ul>
      *          <li> Any of the chunks are {@link ChunkLevelType#INACCESSIBLE INACCESSIBLE} (not loaded).
      *          <li> Any of the specified chunks are currently stepping.
+     *          <li> <code>sprintTicks</code> is less than 0.
      * </ul>
      */
-    void sprintChunk(Collection<? extends ChunkPos> chunks, int sprintTicks);
+    void sprintChunk(World world, Collection<ChunkPos> chunks, int sprintTicks);
 
     /**
      * Sprints the specified chunk for <code>sprintTicks</code> ticks. <p>
@@ -196,8 +207,9 @@ public interface TickRateAPI {
      * <ul>
      *          <li> The chunk is {@link ChunkLevelType#INACCESSIBLE INACCESSIBLE} (not loaded).
      *          <li> The specified chunk is currently stepping.
+     *          <li> <code>sprintTicks</code> is less than 0.
      * </ul>
      */
-    void sprintChunk(ChunkPos chunk, int sprintTicks);
+    void sprintChunk(World world, ChunkPos chunk, int sprintTicks);
 
 }

--- a/src/main/java/io/github/dennisochulor/tickrate/api/TickRateAPI.java
+++ b/src/main/java/io/github/dennisochulor/tickrate/api/TickRateAPI.java
@@ -1,0 +1,78 @@
+package io.github.dennisochulor.tickrate.api;
+
+import io.github.dennisochulor.tickrate.api_impl.TickRateAPIImpl;
+import net.minecraft.entity.Entity;
+import net.minecraft.server.world.ChunkLevelType;
+import net.minecraft.util.math.ChunkPos;
+import net.minecraft.world.World;
+
+import java.util.Collection;
+
+/**
+ * API v0 for TickRate v0.3.0
+ * <p>
+ * This class represents the sole entrypoint for TickRate's API. This API should only be used on the server-side.
+ */
+public interface TickRateAPI {
+
+    /**
+     * Obtain the API instance. This method should only be called after the server has been fully initialised.
+     * @throws IllegalStateException if the server has not been fully intialised yet.
+     */
+    static TickRateAPI getInstance() {
+        return TickRateAPIImpl.getInstance();
+    }
+
+    /**
+     * Returns the tick rate of the entity. <p>
+     * If the entity has no specific tick rate, the tick rate of the chunk it is in will be returned.
+     * If the chunk it is in also has no specific tick rate, the server's tick rate will be returned. <p>
+     *
+     * If the entity is a passenger, the tick rate of its {@link Entity#getRootVehicle() root vehicle} will be returned.
+     *
+     * @throws IllegalArgumentException if {@link Entity#isRemoved()} is true.
+     */
+    float queryEntity(Entity entity);
+
+    void rateEntity(Collection<? extends Entity> entities, float rate);
+
+    void rateEntity(Entity entity, float rate);
+
+    void freezeEntity(Collection<? extends Entity> entities, boolean freeze);
+
+    void freezeEntity(Entity entity, boolean freeze);
+
+    void stepEntity(Collection<? extends Entity> entities, int stepTicks);
+
+    void stepEntity(Entity entity, int stepTicks);
+
+    void sprintEntity(Collection<? extends Entity> entities, int sprintTicks);
+
+    void sprintEntity(Entity entity, int sprintTicks);
+
+
+    /**
+     * Returns the tick rate of the chunk. <p>
+     * If the chunk has no specific tick rate, the server's tick rate will be returned.
+     *
+     * @throws IllegalArgumentException if the chunk's level type is {@link ChunkLevelType#INACCESSIBLE INACCESSIBLE}.
+     */
+    float queryChunk(World world, ChunkPos chunk);
+
+    void rateChunk(Collection<? extends ChunkPos> chunks, float rate);
+
+    void rateChunk(ChunkPos chunk, float rate);
+
+    void freezeChunk(Collection<? extends ChunkPos> chunks, boolean freeze);
+
+    void freezeChunk(ChunkPos chunk, boolean freeze);
+
+    void stepChunk(Collection<? extends ChunkPos> chunks, int stepTicks);
+
+    void stepChunk(ChunkPos chunk, int stepTicks);
+
+    void sprintChunk(Collection<? extends ChunkPos> chunks, int sprintTicks);
+
+    void sprintChunk(ChunkPos chunk, int sprintTicks);
+
+}

--- a/src/main/java/io/github/dennisochulor/tickrate/api/TickRateEvents.java
+++ b/src/main/java/io/github/dennisochulor/tickrate/api/TickRateEvents.java
@@ -8,58 +8,88 @@ import net.minecraft.world.World;
 
 
 /**
- * TickRate related events.
+ * TickRate related events. <p>
+ * These events are fired when the associated <code>/tick</code> command is run and also when the associated
+ * API method is called. Registering event handlers for these events is identical to registering event handlers for Fabric events. <p>
+ *
+ * Unlike {@link TickRateAPI}, event handlers can be registered before the server has fully initialised.
  */
 @SuppressWarnings("unused")
 public interface TickRateEvents {
 
+    /**
+     * Called when the tick rate of an entity has been modified.
+     */
     Event<EntityRate> ENTITY_RATE = EventFactory.createArrayBacked(EntityRate.class, callbacks -> ((entity, rate) -> {
         for (EntityRate callback : callbacks) {
             callback.onEntityRate(entity, rate);
         }
     }));
 
+    /**
+     * Called when an entity is frozen or unfrozen.
+     */
     Event<EntityFreeze> ENTITY_FREEZE = EventFactory.createArrayBacked(EntityFreeze.class, callbacks -> ((entity, freeze) -> {
         for (EntityFreeze callback : callbacks) {
             callback.onEntityFreeze(entity, freeze);
         }
     }));
 
+    /**
+     * Called when an entity starts stepping.
+     */
     Event<EntityStep> ENTITY_STEP = EventFactory.createArrayBacked(EntityStep.class, callbacks -> ((entity, stepTicks) -> {
         for (EntityStep callback : callbacks) {
             callback.onEntityStep(entity, stepTicks);
         }
     }));
 
+    /**
+     * Called when an entity starts sprinting.
+     */
     Event<EntitySprint> ENTITY_SPRINT = EventFactory.createArrayBacked(EntitySprint.class, callbacks -> ((entity, sprintTicks) -> {
         for (EntitySprint callback : callbacks) {
             callback.onEntitySprint(entity, sprintTicks);
         }
     }));
 
+    /**
+     * Called when the tick rate of a chunk is modified.
+     */
     Event<ChunkRate> CHUNK_RATE = EventFactory.createArrayBacked(ChunkRate.class, callbacks -> ((world, chunkPos, rate) -> {
         for (ChunkRate callback : callbacks) {
             callback.onChunkRate(world, chunkPos, rate);
         }
     }));
 
+    /**
+     * Called when a chunk is frozen or unfrozen.
+     */
     Event<ChunkFreeze> CHUNK_FREEZE = EventFactory.createArrayBacked(ChunkFreeze.class, callbacks -> ((world, chunkPos, freeze) -> {
         for (ChunkFreeze callback : callbacks) {
             callback.onChunkFreeze(world, chunkPos, freeze);
         }
     }));
 
+    /**
+     * Called when a chunk starts stepping.
+     */
     Event<ChunkStep> CHUNK_STEP = EventFactory.createArrayBacked(ChunkStep.class, callbacks -> ((world, chunkPos, stepTicks) -> {
         for (ChunkStep callback : callbacks) {
             callback.onChunkStep(world, chunkPos, stepTicks);
         }
     }));
 
+    /**
+     * Called when a chunk starts sprinting.
+     */
     Event<ChunkSprint> CHUNK_SPRINT = EventFactory.createArrayBacked(ChunkSprint.class, callbacks -> ((world, chunkPos, sprintTicks) -> {
         for (ChunkSprint callback : callbacks) {
             callback.onChunkSprint(world, chunkPos, sprintTicks);
         }
     }));
+
+
 
     @FunctionalInterface
     interface EntityRate {

--- a/src/main/java/io/github/dennisochulor/tickrate/api/TickRateEvents.java
+++ b/src/main/java/io/github/dennisochulor/tickrate/api/TickRateEvents.java
@@ -11,94 +11,93 @@ import net.minecraft.world.World;
  * TickRate related events.
  */
 @SuppressWarnings("unused")
-public final class TickRateEvents {
-    private TickRateEvents() {}
+public interface TickRateEvents {
 
-    public static final Event<EntityRate> ENTITY_RATE = EventFactory.createArrayBacked(EntityRate.class, callbacks -> ((entity, rate) -> {
+    Event<EntityRate> ENTITY_RATE = EventFactory.createArrayBacked(EntityRate.class, callbacks -> ((entity, rate) -> {
         for (EntityRate callback : callbacks) {
             callback.onEntityRate(entity, rate);
         }
     }));
 
-    public static final Event<EntityFreeze> ENTITY_FREEZE = EventFactory.createArrayBacked(EntityFreeze.class, callbacks -> ((entity, freeze) -> {
+    Event<EntityFreeze> ENTITY_FREEZE = EventFactory.createArrayBacked(EntityFreeze.class, callbacks -> ((entity, freeze) -> {
         for (EntityFreeze callback : callbacks) {
             callback.onEntityFreeze(entity, freeze);
         }
     }));
 
-    public static final Event<EntityStep> ENTITY_STEP = EventFactory.createArrayBacked(EntityStep.class, callbacks -> ((entity, stepTicks) -> {
+    Event<EntityStep> ENTITY_STEP = EventFactory.createArrayBacked(EntityStep.class, callbacks -> ((entity, stepTicks) -> {
         for (EntityStep callback : callbacks) {
             callback.onEntityStep(entity, stepTicks);
         }
     }));
 
-    public static final Event<EntitySprint> ENTITY_SPRINT = EventFactory.createArrayBacked(EntitySprint.class, callbacks -> ((entity, sprintTicks) -> {
+    Event<EntitySprint> ENTITY_SPRINT = EventFactory.createArrayBacked(EntitySprint.class, callbacks -> ((entity, sprintTicks) -> {
         for (EntitySprint callback : callbacks) {
             callback.onEntitySprint(entity, sprintTicks);
         }
     }));
 
-    public static final Event<ChunkRate> CHUNK_RATE = EventFactory.createArrayBacked(ChunkRate.class, callbacks -> ((world, chunkPos, rate) -> {
+    Event<ChunkRate> CHUNK_RATE = EventFactory.createArrayBacked(ChunkRate.class, callbacks -> ((world, chunkPos, rate) -> {
         for (ChunkRate callback : callbacks) {
             callback.onChunkRate(world, chunkPos, rate);
         }
     }));
 
-    public static final Event<ChunkFreeze> CHUNK_FREEZE = EventFactory.createArrayBacked(ChunkFreeze.class, callbacks -> ((world, chunkPos, freeze) -> {
+    Event<ChunkFreeze> CHUNK_FREEZE = EventFactory.createArrayBacked(ChunkFreeze.class, callbacks -> ((world, chunkPos, freeze) -> {
         for (ChunkFreeze callback : callbacks) {
             callback.onChunkFreeze(world, chunkPos, freeze);
         }
     }));
 
-    public static final Event<ChunkStep> CHUNK_STEP = EventFactory.createArrayBacked(ChunkStep.class, callbacks -> ((world, chunkPos, stepTicks) -> {
+    Event<ChunkStep> CHUNK_STEP = EventFactory.createArrayBacked(ChunkStep.class, callbacks -> ((world, chunkPos, stepTicks) -> {
         for (ChunkStep callback : callbacks) {
             callback.onChunkStep(world, chunkPos, stepTicks);
         }
     }));
 
-    public static final Event<ChunkSprint> CHUNK_SPRINT = EventFactory.createArrayBacked(ChunkSprint.class, callbacks -> ((world, chunkPos, sprintTicks) -> {
+    Event<ChunkSprint> CHUNK_SPRINT = EventFactory.createArrayBacked(ChunkSprint.class, callbacks -> ((world, chunkPos, sprintTicks) -> {
         for (ChunkSprint callback : callbacks) {
             callback.onChunkSprint(world, chunkPos, sprintTicks);
         }
     }));
 
     @FunctionalInterface
-    public interface EntityRate {
+    interface EntityRate {
         void onEntityRate(Entity entity, float rate);
     }
 
     @FunctionalInterface
-    public interface EntityFreeze {
+   interface EntityFreeze {
         void onEntityFreeze(Entity entity, boolean freeze);
     }
 
     @FunctionalInterface
-    public interface EntityStep {
+    interface EntityStep {
         void onEntityStep(Entity entity, int stepTicks);
     }
 
     @FunctionalInterface
-    public interface EntitySprint {
+    interface EntitySprint {
         void onEntitySprint(Entity entity, int sprintTicks);
     }
 
     @FunctionalInterface
-    public interface ChunkRate {
+    interface ChunkRate {
         void onChunkRate(World world, ChunkPos chunkPos, float rate);
     }
 
     @FunctionalInterface
-    public interface ChunkFreeze {
+    interface ChunkFreeze {
         void onChunkFreeze(World world, ChunkPos chunkPos, boolean freeze);
     }
 
     @FunctionalInterface
-    public interface ChunkStep {
+    interface ChunkStep {
         void onChunkStep(World world, ChunkPos chunkPos, int stepTicks);
     }
 
     @FunctionalInterface
-    public interface ChunkSprint {
+    interface ChunkSprint {
         void onChunkSprint(World world, ChunkPos chunkPos, int sprintTicks);
     }
 

--- a/src/main/java/io/github/dennisochulor/tickrate/api/TickRateEvents.java
+++ b/src/main/java/io/github/dennisochulor/tickrate/api/TickRateEvents.java
@@ -1,0 +1,105 @@
+package io.github.dennisochulor.tickrate.api;
+
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+import net.minecraft.entity.Entity;
+import net.minecraft.util.math.ChunkPos;
+import net.minecraft.world.World;
+
+
+/**
+ * TickRate related events.
+ */
+@SuppressWarnings("unused")
+public final class TickRateEvents {
+    private TickRateEvents() {}
+
+    public static final Event<EntityRate> ENTITY_RATE = EventFactory.createArrayBacked(EntityRate.class, callbacks -> ((entity, rate) -> {
+        for (EntityRate callback : callbacks) {
+            callback.onEntityRate(entity, rate);
+        }
+    }));
+
+    public static final Event<EntityFreeze> ENTITY_FREEZE = EventFactory.createArrayBacked(EntityFreeze.class, callbacks -> ((entity, freeze) -> {
+        for (EntityFreeze callback : callbacks) {
+            callback.onEntityFreeze(entity, freeze);
+        }
+    }));
+
+    public static final Event<EntityStep> ENTITY_STEP = EventFactory.createArrayBacked(EntityStep.class, callbacks -> ((entity, stepTicks) -> {
+        for (EntityStep callback : callbacks) {
+            callback.onEntityStep(entity, stepTicks);
+        }
+    }));
+
+    public static final Event<EntitySprint> ENTITY_SPRINT = EventFactory.createArrayBacked(EntitySprint.class, callbacks -> ((entity, sprintTicks) -> {
+        for (EntitySprint callback : callbacks) {
+            callback.onEntitySprint(entity, sprintTicks);
+        }
+    }));
+
+    public static final Event<ChunkRate> CHUNK_RATE = EventFactory.createArrayBacked(ChunkRate.class, callbacks -> ((world, chunkPos, rate) -> {
+        for (ChunkRate callback : callbacks) {
+            callback.onChunkRate(world, chunkPos, rate);
+        }
+    }));
+
+    public static final Event<ChunkFreeze> CHUNK_FREEZE = EventFactory.createArrayBacked(ChunkFreeze.class, callbacks -> ((world, chunkPos, freeze) -> {
+        for (ChunkFreeze callback : callbacks) {
+            callback.onChunkFreeze(world, chunkPos, freeze);
+        }
+    }));
+
+    public static final Event<ChunkStep> CHUNK_STEP = EventFactory.createArrayBacked(ChunkStep.class, callbacks -> ((world, chunkPos, stepTicks) -> {
+        for (ChunkStep callback : callbacks) {
+            callback.onChunkStep(world, chunkPos, stepTicks);
+        }
+    }));
+
+    public static final Event<ChunkSprint> CHUNK_SPRINT = EventFactory.createArrayBacked(ChunkSprint.class, callbacks -> ((world, chunkPos, sprintTicks) -> {
+        for (ChunkSprint callback : callbacks) {
+            callback.onChunkSprint(world, chunkPos, sprintTicks);
+        }
+    }));
+
+    @FunctionalInterface
+    public interface EntityRate {
+        void onEntityRate(Entity entity, float rate);
+    }
+
+    @FunctionalInterface
+    public interface EntityFreeze {
+        void onEntityFreeze(Entity entity, boolean freeze);
+    }
+
+    @FunctionalInterface
+    public interface EntityStep {
+        void onEntityStep(Entity entity, int stepTicks);
+    }
+
+    @FunctionalInterface
+    public interface EntitySprint {
+        void onEntitySprint(Entity entity, int sprintTicks);
+    }
+
+    @FunctionalInterface
+    public interface ChunkRate {
+        void onChunkRate(World world, ChunkPos chunkPos, float rate);
+    }
+
+    @FunctionalInterface
+    public interface ChunkFreeze {
+        void onChunkFreeze(World world, ChunkPos chunkPos, boolean freeze);
+    }
+
+    @FunctionalInterface
+    public interface ChunkStep {
+        void onChunkStep(World world, ChunkPos chunkPos, int stepTicks);
+    }
+
+    @FunctionalInterface
+    public interface ChunkSprint {
+        void onChunkSprint(World world, ChunkPos chunkPos, int sprintTicks);
+    }
+
+}

--- a/src/main/java/io/github/dennisochulor/tickrate/api/TickRateEvents.java
+++ b/src/main/java/io/github/dennisochulor/tickrate/api/TickRateEvents.java
@@ -19,6 +19,43 @@ import net.minecraft.world.World;
 public interface TickRateEvents {
 
     /**
+     * Called when the tick rate of the server has been modified.
+     */
+    Event<ServerRate> SERVER_RATE = EventFactory.createArrayBacked(ServerRate.class, callbacks -> rate -> {
+        for (ServerRate callback : callbacks) {
+            callback.onServerRate(rate);
+        }
+    });
+
+    /**
+     * Called when the server is frozen or unfrozen.
+     */
+    Event<ServerFreeze> SERVER_FREEZE = EventFactory.createArrayBacked(ServerFreeze.class, callbacks -> freeze -> {
+        for (ServerFreeze callback : callbacks) {
+            callback.onServerFreeze(freeze);
+        }
+    });
+
+    /**
+     * Called when the server starts stepping.
+     */
+    Event<ServerStep> SERVER_STEP = EventFactory.createArrayBacked(ServerStep.class, callbacks -> stepTicks -> {
+        for (ServerStep callback : callbacks) {
+            callback.onServerStep(stepTicks);
+        }
+    });
+
+    /**
+     * Called when the server starts sprinting.
+     */
+    Event<ServerSprint> SERVER_SPRINT = EventFactory.createArrayBacked(ServerSprint.class, callbacks -> sprintTicks -> {
+        for (ServerSprint callback : callbacks) {
+            callback.onServerSprint(sprintTicks);
+        }
+    });
+
+
+    /**
      * Called when the tick rate of an entity has been modified. <p>
      * If the entity's rate has been reset, <code>rate</code> will be 0.
      */
@@ -54,6 +91,7 @@ public interface TickRateEvents {
             callback.onEntitySprint(entity, sprintTicks);
         }
     }));
+
 
     /**
      * Called when the tick rate of a chunk is modified. <p>
@@ -93,6 +131,26 @@ public interface TickRateEvents {
     }));
 
 
+
+    @FunctionalInterface
+    interface ServerRate {
+        void onServerRate(float rate);
+    }
+
+    @FunctionalInterface
+    interface ServerFreeze {
+        void onServerFreeze(boolean freeze);
+    }
+
+    @FunctionalInterface
+    interface ServerStep {
+        void onServerStep(int stepTicks);
+    }
+
+    @FunctionalInterface
+    interface ServerSprint {
+        void onServerSprint(int sprintTicks);
+    }
 
     @FunctionalInterface
     interface EntityRate {

--- a/src/main/java/io/github/dennisochulor/tickrate/api/TickRateEvents.java
+++ b/src/main/java/io/github/dennisochulor/tickrate/api/TickRateEvents.java
@@ -12,13 +12,15 @@ import net.minecraft.world.World;
  * These events are fired when the associated <code>/tick</code> command is run and also when the associated
  * API method is called. Registering event handlers for these events is identical to registering event handlers for Fabric events. <p>
  *
- * Unlike {@link TickRateAPI}, event handlers can be registered before the server has fully initialised.
+ * Unlike {@link TickRateAPI}, event handlers can be registered before the server has fully initialised. <p>
+ * It should be noted that these events do not necessarily fire immediately when a modification is made, there may be a delay
+ * of a couple ticks. Though usually it will be fired within the same tick.
  */
-@SuppressWarnings("unused")
 public interface TickRateEvents {
 
     /**
-     * Called when the tick rate of an entity has been modified.
+     * Called when the tick rate of an entity has been modified. <p>
+     * If the entity's rate has been reset, <code>rate</code> will be 0.
      */
     Event<EntityRate> ENTITY_RATE = EventFactory.createArrayBacked(EntityRate.class, callbacks -> ((entity, rate) -> {
         for (EntityRate callback : callbacks) {
@@ -54,7 +56,8 @@ public interface TickRateEvents {
     }));
 
     /**
-     * Called when the tick rate of a chunk is modified.
+     * Called when the tick rate of a chunk is modified. <p>
+     * If the chunk's rate has been reset, <code>rate</code> will be 0.
      */
     Event<ChunkRate> CHUNK_RATE = EventFactory.createArrayBacked(ChunkRate.class, callbacks -> ((world, chunkPos, rate) -> {
         for (ChunkRate callback : callbacks) {
@@ -93,6 +96,9 @@ public interface TickRateEvents {
 
     @FunctionalInterface
     interface EntityRate {
+        /**
+         * If the entity's rate has been reset, <code>rate</code> will be 0.
+         */
         void onEntityRate(Entity entity, float rate);
     }
 
@@ -113,6 +119,9 @@ public interface TickRateEvents {
 
     @FunctionalInterface
     interface ChunkRate {
+        /**
+         * If the chunk's rate has been reset, <code>rate</code> will be 0.
+         */
         void onChunkRate(World world, ChunkPos chunkPos, float rate);
     }
 

--- a/src/main/java/io/github/dennisochulor/tickrate/api_impl/TickRateAPIImpl.java
+++ b/src/main/java/io/github/dennisochulor/tickrate/api_impl/TickRateAPIImpl.java
@@ -1,0 +1,31 @@
+package io.github.dennisochulor.tickrate.api_impl;
+
+import io.github.dennisochulor.tickrate.api.TickRateAPI;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.ServerTickManager;
+
+public final class TickRateAPIImpl implements TickRateAPI {
+
+    private static TickRateAPI INSTANCE;
+
+    public static TickRateAPI getInstance() {
+        if(INSTANCE == null) throw new IllegalStateException("The MinecraftServer must be fully initialised first before using the TickRateAPI!");
+        return INSTANCE;
+    }
+
+    /** Only ever called ONCE by TickRate's ModInitializer */
+    public static void init(MinecraftServer server) {
+        if(INSTANCE != null) throw new IllegalStateException("Only one instance can be created!");
+        INSTANCE = new TickRateAPIImpl(server);
+    }
+
+
+    private final MinecraftServer server;
+    private final ServerTickManager tickManager;
+
+    private TickRateAPIImpl(MinecraftServer server) {
+        this.server = server;
+        this.tickManager = this.server.getTickManager();
+    }
+
+}

--- a/src/main/java/io/github/dennisochulor/tickrate/api_impl/TickRateAPIImpl.java
+++ b/src/main/java/io/github/dennisochulor/tickrate/api_impl/TickRateAPIImpl.java
@@ -25,10 +25,15 @@ public final class TickRateAPIImpl implements TickRateAPI {
         return INSTANCE;
     }
 
-    /** Only ever called ONCE by TickRate's ModInitializer */
+    /** Only ever called when the logical server is fully initialised */
     public static void init(MinecraftServer server) {
-        if(INSTANCE != null) throw new IllegalStateException("Only one instance can be created!");
+        if(INSTANCE != null) throw new IllegalStateException("Only one instance can be present at any given time!");
         INSTANCE = new TickRateAPIImpl(server);
+    }
+
+    /** Only ever called when the logical server starts shutting down */
+    public static void uninit() {
+        INSTANCE = null;
     }
 
 

--- a/src/main/java/io/github/dennisochulor/tickrate/api_impl/TickRateAPIImpl.java
+++ b/src/main/java/io/github/dennisochulor/tickrate/api_impl/TickRateAPIImpl.java
@@ -1,8 +1,20 @@
 package io.github.dennisochulor.tickrate.api_impl;
 
 import io.github.dennisochulor.tickrate.api.TickRateAPI;
+import io.github.dennisochulor.tickrate.api.TickRateEvents;
+import net.minecraft.entity.Entity;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.ServerTickManager;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ChunkLevelType;
+import net.minecraft.util.math.ChunkPos;
+import net.minecraft.world.World;
+import net.minecraft.world.chunk.ChunkStatus;
+import net.minecraft.world.chunk.WorldChunk;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
 
 public final class TickRateAPIImpl implements TickRateAPI {
 
@@ -26,6 +38,173 @@ public final class TickRateAPIImpl implements TickRateAPI {
     private TickRateAPIImpl(MinecraftServer server) {
         this.server = server;
         this.tickManager = this.server.getTickManager();
+    }
+
+
+    private void entityCheck(Collection<? extends Entity> entities) throws IllegalArgumentException {
+        Objects.requireNonNull(entities, "entities cannot be null!");
+        entities.forEach(entity -> {
+            if(entity instanceof ServerPlayerEntity player && !tickManager.tickRate$hasClientMod(player))
+                throw new IllegalArgumentException("Some of the specified entities are players that do not have TickRate mod installed on their client, so their tick rate cannot be manipulated.");
+            if(entity.isRemoved()) throw new IllegalArgumentException("Entity must not be removed!");
+        });
+    }
+
+    private void chunkCheck(World world, Collection<ChunkPos> chunks) throws IllegalArgumentException {
+        Objects.requireNonNull(world, "world cannot be null!");
+        Objects.requireNonNull(chunks, "chunks cannot be null!");
+        chunks.forEach(chunkPos -> {
+            WorldChunk worldChunk = (WorldChunk) world.getChunk(chunkPos.x,chunkPos.z,ChunkStatus.FULL,false);
+            if(worldChunk==null || worldChunk.getLevelType() == ChunkLevelType.INACCESSIBLE)
+                throw new IllegalArgumentException("Some of the specified chunks are not loaded!");
+        });
+    }
+
+    private void send(Runnable runnable) {
+        server.send(server.createTask(runnable));
+    }
+
+
+    // API Implementation
+
+    @Override
+    public float queryEntity(Entity entity) {
+        entityCheck(List.of(entity));
+        return tickManager.tickRate$getEntityRate(entity);
+    }
+
+    @Override
+    public void rateEntity(Collection<? extends Entity> entities, float rate) {
+        if(rate < 1.0f && rate != 0.0f) throw new IllegalArgumentException("rate must be >= 1 or exactly 0");
+        entityCheck(entities);
+
+        int roundRate = Math.round(rate);
+        tickManager.tickRate$setEntityRate(roundRate, entities);
+        tickManager.tickRate$sendUpdatePacket();
+        send(() -> entities.forEach(entity -> TickRateEvents.ENTITY_RATE.invoker().onEntityRate(entity, roundRate)));
+    }
+
+    @Override
+    public void rateEntity(Entity entity, float rate) {
+        rateEntity(List.of(entity), rate);
+    }
+
+    @Override
+    public void freezeEntity(Collection<? extends Entity> entities, boolean freeze) {
+        entityCheck(entities);
+
+        tickManager.tickRate$setEntityFrozen(freeze, entities);
+        tickManager.tickRate$sendUpdatePacket();
+        send(() -> entities.forEach(entity -> TickRateEvents.ENTITY_FREEZE.invoker().onEntityFreeze(entity, freeze)));
+    }
+
+    @Override
+    public void freezeEntity(Entity entity, boolean freeze) {
+        freezeEntity(List.of(entity), freeze);
+    }
+
+    @Override
+    public void stepEntity(Collection<? extends Entity> entities, int stepTicks) {
+        if(stepTicks < 0) throw new IllegalArgumentException("stepTicks must be >= 0");
+        entityCheck(entities);
+
+        if(tickManager.tickRate$stepEntity(stepTicks, entities)) {
+            tickManager.tickRate$sendUpdatePacket();
+            if(stepTicks != 0) send(() -> entities.forEach(entity -> TickRateEvents.ENTITY_STEP.invoker().onEntityStep(entity, stepTicks)));
+        }
+        else throw new IllegalArgumentException("All of the specified entities must be frozen first and cannot be sprinting!");
+    }
+
+    @Override
+    public void stepEntity(Entity entity, int stepTicks) {
+        stepEntity(List.of(entity), stepTicks);
+    }
+
+    @Override
+    public void sprintEntity(Collection<? extends Entity> entities, int sprintTicks) {
+        if(sprintTicks < 0) throw new IllegalArgumentException("sprintTicks must be >= 0");
+        entityCheck(entities);
+
+        if(tickManager.tickRate$sprintEntity(sprintTicks, entities)) {
+            tickManager.tickRate$sendUpdatePacket();
+            if(sprintTicks != 0) send(() -> entities.forEach(entity -> TickRateEvents.ENTITY_SPRINT.invoker().onEntitySprint(entity, sprintTicks)));
+        }
+        else throw new IllegalArgumentException("All of the specified entities must not be stepping!");
+    }
+
+    @Override
+    public void sprintEntity(Entity entity, int sprintTicks) {
+        sprintEntity(List.of(entity), sprintTicks);
+    }
+
+    @Override
+    public float queryChunk(World world, ChunkPos chunk) {
+        chunkCheck(world, List.of(chunk));
+        return tickManager.tickRate$getChunkRate(world, chunk.toLong());
+    }
+
+    @Override
+    public void rateChunk(World world, Collection<ChunkPos> chunks, float rate) {
+        if(rate < 1.0f && rate != 0.0f) throw new IllegalArgumentException("rate must be >= 1 or exactly 0");
+        chunkCheck(world, chunks);
+
+        int roundRate = Math.round(rate);
+        tickManager.tickRate$setChunkRate(rate, world, chunks);
+        tickManager.tickRate$sendUpdatePacket();
+        send(() -> chunks.forEach(chunkPos -> TickRateEvents.CHUNK_RATE.invoker().onChunkRate(world, chunkPos, roundRate)));
+    }
+
+    @Override
+    public void rateChunk(World world, ChunkPos chunk, float rate) {
+        rateChunk(world, List.of(chunk), rate);
+    }
+
+    @Override
+    public void freezeChunk(World world, Collection<ChunkPos> chunks, boolean freeze) {
+        chunkCheck(world, chunks);
+
+        tickManager.tickRate$setChunkFrozen(freeze, world, chunks);
+        tickManager.tickRate$sendUpdatePacket();
+        send(() -> chunks.forEach(chunkPos -> TickRateEvents.CHUNK_FREEZE.invoker().onChunkFreeze(world, chunkPos, freeze)));
+    }
+
+    @Override
+    public void freezeChunk(World world, ChunkPos chunk, boolean freeze) {
+        freezeChunk(world, List.of(chunk), freeze);
+    }
+
+    @Override
+    public void stepChunk(World world, Collection<ChunkPos> chunks, int stepTicks) {
+        if(stepTicks < 0) throw new IllegalArgumentException("stepTicks must be >= 0");
+        chunkCheck(world, chunks);
+
+        if(tickManager.tickRate$stepChunk(stepTicks, world, chunks)) {
+            tickManager.tickRate$sendUpdatePacket();
+            if(stepTicks != 0) send(() -> chunks.forEach(chunkPos -> TickRateEvents.CHUNK_STEP.invoker().onChunkStep(world, chunkPos, stepTicks)));
+        }
+        else throw new IllegalArgumentException("All of the specified chunks must be frozen first and cannot be sprinting!");
+    }
+
+    @Override
+    public void stepChunk(World world, ChunkPos chunk, int stepTicks) {
+        stepChunk(world, List.of(chunk), stepTicks);
+    }
+
+    @Override
+    public void sprintChunk(World world, Collection<ChunkPos> chunks, int sprintTicks) {
+        if(sprintTicks < 0) throw new IllegalArgumentException("sprintTicks must be >= 0");
+        chunkCheck(world, chunks);
+
+        if(tickManager.tickRate$sprintChunk(sprintTicks, world, chunks)) {
+            tickManager.tickRate$sendUpdatePacket();
+            if(sprintTicks != 0) send(() -> chunks.forEach(chunkPos -> TickRateEvents.CHUNK_SPRINT.invoker().onChunkSprint(world, chunkPos, sprintTicks)));
+        }
+        else throw new IllegalArgumentException("All of the specified chunks must not be stepping!");
+    }
+
+    @Override
+    public void sprintChunk(World world, ChunkPos chunk, int sprintTicks) {
+        sprintChunk(world, List.of(chunk), sprintTicks);
     }
 
 }

--- a/src/main/java/io/github/dennisochulor/tickrate/injected_interface/TickRateTickManager.java
+++ b/src/main/java/io/github/dennisochulor/tickrate/injected_interface/TickRateTickManager.java
@@ -7,7 +7,6 @@ import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.World;
 
 import java.util.Collection;
-import java.util.List;
 
 public interface TickRateTickManager {
 
@@ -35,11 +34,11 @@ public interface TickRateTickManager {
     default boolean tickRate$stepEntity(int steps, Collection<? extends Entity> entities) {return false;}
     default boolean tickRate$sprintEntity(int ticks, Collection<? extends Entity> entities) {return false;}
 
-    default void tickRate$setChunkRate(float rate, World world, List<ChunkPos> chunks) {}
+    default void tickRate$setChunkRate(float rate, World world, Collection<ChunkPos> chunks) {}
     default float tickRate$getChunkRate(World world, long chunkPos) {return 0;}
-    default void tickRate$setChunkFrozen(boolean frozen, World world, List<ChunkPos> chunks) {}
-    default boolean tickRate$stepChunk(int steps, World world, List<ChunkPos> chunks) {return false;}
-    default boolean tickRate$sprintChunk(int ticks, World world, List<ChunkPos> chunks) {return false;}
+    default void tickRate$setChunkFrozen(boolean frozen, World world, Collection<ChunkPos> chunks) {}
+    default boolean tickRate$stepChunk(int steps, World world, Collection<ChunkPos> chunks) {return false;}
+    default boolean tickRate$sprintChunk(int ticks, World world, Collection<ChunkPos> chunks) {return false;}
 
     default TickState tickRate$getChunkTickState(World world, long chunkPos) {return null;}
     default TickState tickRate$getEntityTickState(Entity entity) {return null;}

--- a/src/main/java/io/github/dennisochulor/tickrate/mixin/ServerTickManagerMixin.java
+++ b/src/main/java/io/github/dennisochulor/tickrate/mixin/ServerTickManagerMixin.java
@@ -362,8 +362,7 @@ public abstract class ServerTickManagerMixin extends TickManager implements Tick
         if(entities.stream().anyMatch(e -> !this.steps.containsKey(e.getUuidAsString()) || this.sprinting.containsKey(e.getUuidAsString()))) {
             return false; // some are not frozen or are sprinting, error
         }
-        if(steps == 0) entities.forEach(e -> this.steps.put(e.getUuidAsString(), 0));
-        else entities.forEach(e -> this.steps.put(e.getUuidAsString(), steps));
+        entities.forEach(e -> this.steps.put(e.getUuidAsString(), steps));
         return true;
     }
 
@@ -381,7 +380,7 @@ public abstract class ServerTickManagerMixin extends TickManager implements Tick
         return getEntityTickState(key);
     }
 
-    public void tickRate$setChunkRate(float rate, World world, List<ChunkPos> chunks) {
+    public void tickRate$setChunkRate(float rate, World world, Collection<ChunkPos> chunks) {
         if(rate == 0) {
             chunks.forEach(chunkPos -> {
                 String key = world.getRegistryKey().getValue() + "-" + chunkPos.toLong();
@@ -401,7 +400,7 @@ public abstract class ServerTickManagerMixin extends TickManager implements Tick
         return nominalTickRate;
     }
 
-    public void tickRate$setChunkFrozen(boolean frozen, World world, List<ChunkPos> chunks) {
+    public void tickRate$setChunkFrozen(boolean frozen, World world, Collection<ChunkPos> chunks) {
         if(frozen) {
             chunks.forEach(chunkPos -> {
                 String key = world.getRegistryKey().getValue() + "-" + chunkPos.toLong();
@@ -414,19 +413,18 @@ public abstract class ServerTickManagerMixin extends TickManager implements Tick
         }
     }
 
-    public boolean tickRate$stepChunk(int steps, World world, List<ChunkPos> chunks) {
+    public boolean tickRate$stepChunk(int steps, World world, Collection<ChunkPos> chunks) {
         boolean error = chunks.stream().anyMatch(chunkPos -> {
             String key = world.getRegistryKey().getValue() + "-" + chunkPos.toLong();
             return !this.steps.containsKey(key) || this.sprinting.containsKey(key);
         });
         if(error) return false; // some are not frozen or are sprinting, error
 
-        if(steps == 0) chunks.forEach(chunkPos -> this.steps.put(world.getRegistryKey().getValue() + "-" + chunkPos.toLong(), 0));
-        else chunks.forEach(chunkPos -> this.steps.put(world.getRegistryKey().getValue() + "-" + chunkPos.toLong(), steps));
+        chunks.forEach(chunkPos -> this.steps.put(world.getRegistryKey().getValue() + "-" + chunkPos.toLong(), steps));
         return true;
     }
 
-    public boolean tickRate$sprintChunk(int ticks, World world, List<ChunkPos> chunks) {
+    public boolean tickRate$sprintChunk(int ticks, World world, Collection<ChunkPos> chunks) {
         if(chunks.stream().anyMatch(chunkPos -> this.steps.getOrDefault(world.getRegistryKey().getValue() + "-" + chunkPos.toLong(),-1) > 0))
             return false; // some are stepping, error
 

--- a/src/main/java/io/github/dennisochulor/tickrate/mixin/TickCommandMixin.java
+++ b/src/main/java/io/github/dennisochulor/tickrate/mixin/TickCommandMixin.java
@@ -189,6 +189,7 @@ public class TickCommandMixin {
         ServerTickManager tickManager = source.getServer().getTickManager();
         tickManager.tickRate$setServerRate(roundRate);
         tickManager.tickRate$sendUpdatePacket();
+        send(source, () -> TickRateEvents.SERVER_RATE.invoker().onServerRate(roundRate));
         source.sendFeedback(() -> Text.translatable("commands.tick.rate.success", roundRate), true);
         return roundRate;
     }
@@ -229,16 +230,19 @@ public class TickCommandMixin {
     @Inject(method = "executeSprint", at = @At("TAIL"))
     private static void executeSprint(ServerCommandSource source, int ticks, CallbackInfoReturnable<Integer> cir) {
         source.getServer().getTickManager().tickRate$sendUpdatePacket();
+        send(source, () -> TickRateEvents.SERVER_SPRINT.invoker().onServerSprint(ticks));
     }
 
     @Inject(method = "executeFreeze", at = @At("TAIL"))
     private static void executeFreeze(ServerCommandSource source, boolean frozen, CallbackInfoReturnable<Integer> cir) {
         source.getServer().getTickManager().tickRate$sendUpdatePacket();
+        send(source, () -> TickRateEvents.SERVER_FREEZE.invoker().onServerFreeze(frozen));
     }
 
     @Inject(method = "executeStep", at = @At("TAIL"))
     private static void executeStep(ServerCommandSource source, int ticks, CallbackInfoReturnable<Integer> cir) {
         source.getServer().getTickManager().tickRate$sendUpdatePacket();
+        send(source, () -> TickRateEvents.SERVER_STEP.invoker().onServerStep(ticks));
     }
 
     @Inject(method = "executeStopStep", at = @At("RETURN"))

--- a/src/main/java/io/github/dennisochulor/tickrate/test/Test.java
+++ b/src/main/java/io/github/dennisochulor/tickrate/test/Test.java
@@ -3,6 +3,7 @@ package io.github.dennisochulor.tickrate.test;
 import io.github.dennisochulor.tickrate.api.TickRateAPI;
 import io.github.dennisochulor.tickrate.api.TickRateEvents;
 import net.minecraft.entity.Entity;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.command.CommandManager;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.util.math.ChunkPos;
@@ -22,19 +23,72 @@ public final class Test {
 
     private static boolean registered = false;
 
-    public static void test(Entity testEntity) {
-        if(!registered) { // only do it once
-            TickRateEvents.ENTITY_RATE.register((entity, rate) -> LOGGER.info("{} rate {}", entity.getUuidAsString(), rate));
-            TickRateEvents.ENTITY_FREEZE.register((entity, freeze) -> LOGGER.info("{} freeze {}", entity.getUuidAsString(), freeze));
-            TickRateEvents.ENTITY_STEP.register((entity, stepTicks) -> LOGGER.info("{} step {}", entity.getUuidAsString(), stepTicks));
-            TickRateEvents.ENTITY_SPRINT.register((entity, sprintTicks) -> LOGGER.info("{} sprint {}", entity.getUuidAsString(), sprintTicks));
+    public static void test(MinecraftServer server) {
+        register();
 
-            TickRateEvents.CHUNK_RATE.register((world, chunkPos, rate) -> LOGGER.info("{} {} rate {}", world.getRegistryKey().getValue(), chunkPos, rate));
-            TickRateEvents.CHUNK_FREEZE.register((world, chunkPos, freeze) -> LOGGER.info("{} {} freeze {}", world.getRegistryKey().getValue(), chunkPos, freeze));
-            TickRateEvents.CHUNK_STEP.register((world, chunkPos, stepTicks) -> LOGGER.info("{} {} step {}", world.getRegistryKey().getValue(), chunkPos, stepTicks));
-            TickRateEvents.CHUNK_SPRINT.register((world, chunkPos, sprintTicks) -> LOGGER.info("{} {} sprint {}", world.getRegistryKey().getValue(), chunkPos, sprintTicks));
-            registered = true;
-        }
+        Thread.ofVirtual().name("TickRateTest Thread").start(() -> {
+            TickRateAPI api = TickRateAPI.getInstance();
+            ServerCommandSource src = server.getCommandSource();
+            CommandManager commander = server.getCommandManager();
+
+            LOGGER.info("STARTING TICKRATE **API** SERVER TEST");
+            sleep(5);
+
+            api.rateServer(10);
+            LOGGER.info("{} TPS", api.queryServer());
+            sleep(2);
+            api.freezeServer(true);
+            sleep(2);
+
+            api.stepServer(50);
+            sleep(7);
+            api.stepServer(10000);
+            sleep(2);
+            api.stepServer(0);
+            sleep(2);
+
+            api.sprintServer(1000000);
+            sleep(5);
+            api.sprintServer(0);
+            sleep(2);
+            api.freezeServer(false);
+            sleep(2);
+            api.rateServer(20);
+            sleep(2);
+            LOGGER.info("FINISH TICKRATE **API** SERVER TEST");
+
+            sleep(2);
+
+            LOGGER.info("STARTING TICKRATE **COMMAND** SERVER TEST");
+            sleep(5);
+
+            commander.executeWithPrefix(src, "tick rate 10");
+            commander.executeWithPrefix(src, "tick query");
+            sleep(2);
+            commander.executeWithPrefix(src, "tick freeze");
+            sleep(2);
+
+            commander.executeWithPrefix(src, "tick step 50");
+            sleep(7);
+            commander.executeWithPrefix(src, "tick step 10000");
+            sleep(2);
+            commander.executeWithPrefix(src, "tick step stop");
+            sleep(2);
+
+            commander.executeWithPrefix(src, "tick sprint 1000000");
+            sleep(5);
+            commander.executeWithPrefix(src, "tick sprint stop");
+            sleep(2);
+            commander.executeWithPrefix(src, "tick unfreeze");
+            sleep(2);
+            commander.executeWithPrefix(src, "tick rate 20");
+            sleep(2);
+            LOGGER.info("FINISH TICKRATE **COMMAND** SERVER TEST");
+        });
+    }
+
+    public static void test(Entity testEntity) {
+        register();
 
         Thread.ofVirtual().name("TickRateTest Thread").start(() -> {
             TickRateAPI api = TickRateAPI.getInstance();
@@ -155,6 +209,26 @@ public final class Test {
         }
         catch (InterruptedException e) {
             throw new RuntimeException(e);
+        }
+    }
+
+    private static void register() {
+        if(!registered) { // only do it once
+            TickRateEvents.SERVER_RATE.register(rate -> LOGGER.info("server rate {}", rate));
+            TickRateEvents.SERVER_FREEZE.register(freeze -> LOGGER.info("server freeze {}", freeze));
+            TickRateEvents.SERVER_STEP.register(stepTicks -> LOGGER.info("server step {}", stepTicks));
+            TickRateEvents.SERVER_SPRINT.register(sprintTicks -> LOGGER.info("server sprint {}", sprintTicks));
+
+            TickRateEvents.ENTITY_RATE.register((entity, rate) -> LOGGER.info("{} rate {}", entity.getUuidAsString(), rate));
+            TickRateEvents.ENTITY_FREEZE.register((entity, freeze) -> LOGGER.info("{} freeze {}", entity.getUuidAsString(), freeze));
+            TickRateEvents.ENTITY_STEP.register((entity, stepTicks) -> LOGGER.info("{} step {}", entity.getUuidAsString(), stepTicks));
+            TickRateEvents.ENTITY_SPRINT.register((entity, sprintTicks) -> LOGGER.info("{} sprint {}", entity.getUuidAsString(), sprintTicks));
+
+            TickRateEvents.CHUNK_RATE.register((world, chunkPos, rate) -> LOGGER.info("{} {} rate {}", world.getRegistryKey().getValue(), chunkPos, rate));
+            TickRateEvents.CHUNK_FREEZE.register((world, chunkPos, freeze) -> LOGGER.info("{} {} freeze {}", world.getRegistryKey().getValue(), chunkPos, freeze));
+            TickRateEvents.CHUNK_STEP.register((world, chunkPos, stepTicks) -> LOGGER.info("{} {} step {}", world.getRegistryKey().getValue(), chunkPos, stepTicks));
+            TickRateEvents.CHUNK_SPRINT.register((world, chunkPos, sprintTicks) -> LOGGER.info("{} {} sprint {}", world.getRegistryKey().getValue(), chunkPos, sprintTicks));
+            registered = true;
         }
     }
 

--- a/src/main/java/io/github/dennisochulor/tickrate/test/Test.java
+++ b/src/main/java/io/github/dennisochulor/tickrate/test/Test.java
@@ -1,0 +1,79 @@
+package io.github.dennisochulor.tickrate.test;
+
+import io.github.dennisochulor.tickrate.api.TickRateAPI;
+import io.github.dennisochulor.tickrate.api.TickRateEvents;
+import net.minecraft.entity.Entity;
+import net.minecraft.util.math.ChunkPos;
+import net.minecraft.world.World;
+
+import static io.github.dennisochulor.tickrate.TickRate.LOGGER;
+
+public final class Test {
+
+    private static boolean registered = false;
+
+    public static void test(Entity testEntity) {
+        if(!registered) { // only do it once
+            TickRateEvents.ENTITY_RATE.register((entity, rate) -> LOGGER.info("{} rate {}", entity.getUuidAsString(), rate));
+            TickRateEvents.ENTITY_FREEZE.register((entity, freeze) -> LOGGER.info("{} freeze {}", entity.getUuidAsString(), freeze));
+            TickRateEvents.ENTITY_STEP.register((entity, stepTicks) -> LOGGER.info("{} step {}", entity.getUuidAsString(), stepTicks));
+            TickRateEvents.ENTITY_SPRINT.register((entity, sprintTicks) -> LOGGER.info("{} sprint {}", entity.getUuidAsString(), sprintTicks));
+
+            TickRateEvents.CHUNK_RATE.register((world, chunkPos, rate) -> LOGGER.info("{} {} rate {}", world.getRegistryKey().getValue(), chunkPos, rate));
+            TickRateEvents.CHUNK_FREEZE.register((world, chunkPos, freeze) -> LOGGER.info("{} {} freeze {}", world.getRegistryKey().getValue(), chunkPos, freeze));
+            TickRateEvents.CHUNK_STEP.register((world, chunkPos, stepTicks) -> LOGGER.info("{} {} step {}", world.getRegistryKey().getValue(), chunkPos, stepTicks));
+            TickRateEvents.CHUNK_SPRINT.register((world, chunkPos, sprintTicks) -> LOGGER.info("{} {} sprint {}", world.getRegistryKey().getValue(), chunkPos, sprintTicks));
+            registered = true;
+        }
+
+        Thread.ofVirtual().name("TickRateTest Thread").start(() -> {
+            TickRateAPI api = TickRateAPI.getInstance();
+            World world = testEntity.getWorld();
+            ChunkPos chunkPos = testEntity.getChunkPos();
+
+            LOGGER.info("STARTING TICKRATE TEST");
+            sleep(5);
+
+            LOGGER.info("ENTITY TEST");
+            api.rateEntity(testEntity, 10);
+            sleep(2);
+            api.freezeEntity(testEntity, true);
+            sleep(2);
+            api.stepEntity(testEntity, 50);
+            sleep(7);
+            api.sprintEntity(testEntity, 4000);
+            sleep(5);
+            api.freezeEntity(testEntity, false);
+            sleep(2);
+            api.rateEntity(testEntity, 0.0f);
+            sleep(5);
+
+            LOGGER.info("CHUNK TESTS");
+            api.rateChunk(world, chunkPos, 50);
+            sleep(2);
+            api.freezeChunk(world, chunkPos, true);
+            sleep(2);
+            api.stepChunk(world, chunkPos, 250);
+            sleep(7);
+            api.sprintChunk(world, chunkPos, 4000);
+            sleep(5);
+            api.freezeChunk(world, chunkPos, false);
+            sleep(2);
+            api.rateChunk(world, chunkPos, 0.0f);
+            sleep(2);
+            LOGGER.info("FINISH TICKRATE TEST");
+        });
+
+
+    }
+
+    private static void sleep(int seconds) {
+        try {
+            Thread.sleep(seconds * 1000L);
+        }
+        catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -9,7 +9,7 @@
 	],
 	"contact": {
 		"sources": "https://github.com/DennisOchulor/TickRate",
-		"issues": "https://forms.gle/GLCta8sHF8V3Poi88",
+		"issues": "https://gist.github.com/DennisOchulor/3882fbed8efcffcc61b60db49a2ecc4c",
 		"homepage": "https://modrinth.com/mod/tick"
 	},
 	"license": "MIT",


### PR DESCRIPTION
This PR adds an API for the TickRate mod to be used by other mods.

The API includes the following:

1. Query/rate/freeze/unfreeze/step/sprint entities and chunks
2. Events for when entities and chunks rate/freeze/step/sprint status is modified

Closes #3 